### PR TITLE
Fix OpClosure obfuscation

### DIFF
--- a/src/obfuscator/vm/opcode_strings.rs
+++ b/src/obfuscator/vm/opcode_strings.rs
@@ -187,10 +187,10 @@ pub fn get_opcode_string(opcode: &OpcodeType) -> String {
             for i = 1, nups do
                 local pseudo = code[pc + i - 1]
 
-                if pseudo.op == 0 then -- @MOVE
-                    uvlist[i - 1] = open_lua_upvalue(open_list, pseudo[3], memory)
-                elseif pseudo.op == 4 then -- @GETUPVAL
-                    uvlist[i - 1] = upvals[pseudo[3]]
+                if pseudo[$OPCODE$] == $MOVE_OPCODE$ then -- @MOVE
+                    uvlist[i - 1] = open_lua_upvalue(open_list, pseudo[$B_REGISTER$], memory)
+                elseif pseudo[$OPCODE$] == $GETUPVAL_OPCODE$ then -- @GETUPVAL
+                    uvlist[i - 1] = upvals[pseudo[$B_REGISTER$]]
                 end
             end
 

--- a/src/obfuscator/vm/opcode_strings.rs
+++ b/src/obfuscator/vm/opcode_strings.rs
@@ -178,7 +178,7 @@ pub fn get_opcode_string(opcode: &OpcodeType) -> String {
         TableMove(memory, A + 1, A + len, offset + 1, tab)",
         OpcodeType::OpClose => "close_lua_upvalues(open_list, inst[$A_REGISTER$])",
         OpcodeType::OpClosure => "local sub = subs[inst[$B_REGISTER$] + 1] -- offset for 1 based index
-        local nups = sub[2]
+        local nups = sub[$UPVALUE_COUNT$]
         local uvlist
 
         if nups ~= 0 then

--- a/src/obfuscator/vm_generator.rs
+++ b/src/obfuscator/vm_generator.rs
@@ -138,7 +138,7 @@ impl VMGenerator {
         ];
         chunk_component_list.shuffle(&mut rand);
 
-        let obfuscation_context = create_context(constant_list, opcode_list, chunk_component_list);
+        let obfuscation_context = create_context(constant_list, opcode_list.clone(), chunk_component_list);
 
         let mut serializer = Serializer::new(obfuscation_context.clone(), settings.clone());
         let bytes = serializer.serialze(main_chunk);
@@ -313,6 +313,20 @@ impl VMGenerator {
 
         for (i, rename) in rename_map.iter().enumerate() {
             vm_string = vm_string.replace(&format!("${}$", *rename), &(i + 1).to_string());
+        }
+
+        //todo: banish this to hell (aka find a better implementation)
+        let move_opcode = opcode_list.iter().position(|&r| r == OpcodeType::OpMove);
+        let getuv_opcode = opcode_list.iter().position(|&r| r == OpcodeType::OpGetUpval);
+        if move_opcode != None {
+            vm_string = vm_string.replace("$MOVE_OPCODE$", &move_opcode.unwrap().to_string())
+        } else {
+            vm_string = vm_string.replace("$MOVE_OPCODE$", "-1") //idk anymore
+        }
+        if getuv_opcode != None {
+            vm_string = vm_string.replace("$GETUPVAL_OPCODE$", &getuv_opcode.unwrap().to_string());
+        } else {
+            vm_string = vm_string.replace("$GETUPVAL_OPCODE$", "-1");
         }
 
         vm_string


### PR DESCRIPTION
This is half of the way to fixing the issue experienced in #7. This is also very much a temporary and ugly fix but this is the first time I've ever written rust code so its as good as it's getting

OpConcat seems to be really disliking the idea of being functional code, not sure whats up there. The example in #7 now works *only if test is not a local variable* - otherwise, something (what exactly I'm not sure, maybe upvalue magic) fails, and it doesn't end up being in the memory table once the concat starts